### PR TITLE
Make logs more useful

### DIFF
--- a/src/lib/compilers/mods-compiler.ts
+++ b/src/lib/compilers/mods-compiler.ts
@@ -149,9 +149,9 @@ export async function ModsCompiler(pzpwConfig: PZPWConfig, modIds: string[], cac
 
     await generateModInfo(pzpwConfig, modId, modOutDir);
     await copyImages(modOutDir, modId);
+    await copyLicenseFile(modOutDir, modId);
     await copyMedia(modOutDir, modId);
     await copySourceFiles(rootDir, modOutDir, modId);
-    await copyLicenseFile(modOutDir, modId);
 
     const [luaModules, luaSources] = partitionBy(
       Object.entries(files),
@@ -168,17 +168,19 @@ export async function ModsCompiler(pzpwConfig: PZPWConfig, modIds: string[], cac
       await writeFile(luaOutPath, code);
     }
 
-    logger.log(logger.color.info(`\n- Copying lua modules...`));
-    const modules = mergeFilesByModule(Object.fromEntries(luaModules));
-    const modulesDir = join(modOutDir, normalize(LUA_SHARED_MODULES_DIR));
-    await mkdir(modulesDir, { recursive: true });
-    for (const moduleName in modules) {
-      logger.log(logger.color.info(moduleName), logger.color.info(`Copying lua module to '${modulesDir}'.`));
+    if (luaModules.length) {
+      logger.log(logger.color.info(`\n- Copying lua modules...`));
+      const modules = mergeFilesByModule(Object.fromEntries(luaModules));
+      const modulesDir = join(modOutDir, normalize(LUA_SHARED_MODULES_DIR));
+      await mkdir(modulesDir, { recursive: true });
+      for (const moduleName in modules) {
+        logger.log(logger.color.info(moduleName), logger.color.info(`Copying lua module to '${modulesDir}'.`));
 
-      for (const module of modules[moduleName]) {
-        const key = Object.keys(module)[0];
-        await mkdir(dirname(join(modulesDir, key)), { recursive: true });
-        await writeFile(join(modulesDir, key), module[key]);
+        for (const module of modules[moduleName]) {
+          const key = Object.keys(module)[0];
+          await mkdir(dirname(join(modulesDir, key)), { recursive: true });
+          await writeFile(join(modulesDir, key), module[key]);
+        }
       }
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -140,3 +140,16 @@ export function getTsConfig(searchPath = "./", configName = "tsconfig.json") {
   const configFile = ts.readConfigFile(configFileName, ts.sys.readFile);
   return ts.parseJsonConfigFileContent(configFile.config, ts.sys, "./");
 }
+
+/**
+ * Find line and column of text by position
+ * @param {string} text
+ * @param {number} pos
+ * @returns {number[]}
+ */
+export function findPos(text: string, pos: number) {
+  const textLines = text.substring(0, pos).split("\n");
+  const line = textLines.length;
+  const column = textLines[line - 1].length + 1;
+  return [line, column];
+}


### PR DESCRIPTION
Add line:column support to errors in source file
![image](https://user-images.githubusercontent.com/46358138/236071881-87559c6c-446c-441a-a5af-5907c3c3e398.png)

Changed the log output order to a more logical one and removed the output about modules, if there are none
![image](https://user-images.githubusercontent.com/46358138/236072513-2226f76b-f9d0-43f8-8c09-fba0ca74a3ce.png)

